### PR TITLE
[darwin-arm64] Update binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Downloaded from the sources listed at [ffmpeg.org](https://ffmpeg.org/download.h
 
 - Linux (armhf, arm64, ia32, x64) (20220910-c92edd9): https://www.johnvansickle.com/ffmpeg/
 - macOS (x64) (20230213-f8d6d0f): https://evermeet.cx/ffmpeg/
-- macOS (arm64) (4.4.1): contributed by [wongyiuhang](https://github.com/wongyiuhang)
+- macOS (arm64) (5.1.2-7268323): contributed by [wongyiuhang](https://github.com/wongyiuhang)
 - Windows 32-bit (20230213-f8d6d0f): https://github.com/sudo-nautilus/FFmpeg-Builds-Win32/
 - Windows 64-bit (20230213-2296078): https://www.gyan.dev/ffmpeg/builds/
 

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ffprobe-installer/darwin-arm64",
-  "version": "5.0.1",
+  "version": "5.1.2",
   "description": "Mac OS X FFmpeg binary used by ffprobe-installer",
   "homepage": "https://gist.github.com/wongyiuhang/d207aaf554e1985dd283a2fa1df949af",
   "scripts": {
@@ -23,5 +23,5 @@
   ],
   "author": "Honeyside",
   "license": "LGPL-2.1",
-  "ffprobe": "4.4.1"
+  "ffprobe": "n5.1.2-12-g7268323193"
 }


### PR DESCRIPTION
As discussed in https://github.com/SavageCore/node-ffprobe-installer/pull/200#issuecomment-1110834244, a new version of ffprobe on darwin-arm64 is compiled.

@JuanIrache, may you help and confirm the new binary extracts rotation before we merge the update? Thank you🙏

[ffprobe(5.1.2)](https://github.com/wongyiuhang/node-ffprobe-installer/blob/034af4febaca1cdc2994598fc98505fc22602b72/platforms/darwin-arm64/ffprobe)