### PR TITLE
Added TypeScript Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 *.tgz
 .nyc_output
 coverage.lcov
+types/**/*.d.ts
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npm run types
 npm test

--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ if (verifyFile(npm3Binary)) {
 const version = packageJson.ffprobe || packageJson.version;
 const url = packageJson.homepage;
 
+/**
+* @type {{
+* 	path: string;
+* 	version: string;
+* 	url: string;
+* }}
+*/
 module.exports = {
 	path: ffprobePath,
 	version,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"preversion": "npm run test",
 		"types": "tsc",
 		"test": "xo && nyc ava && nyc report --reporter=text-lcov > coverage.lcov && codecov -t 54b3d620-a296-4d71-a717-c3e6e24ae9d9",
-		"prepare": "husky install && shx rm -rf .git/hooks && shx ln -s ../.husky .git/hooks"
+		"prepare": "npm run types && husky install && shx rm -rf .git/hooks && shx ln -s ../.husky .git/hooks"
 	},
 	"types": "types/index.d.ts",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
 	"scripts": {
 		"lint": "xo",
 		"preversion": "npm run test",
+		"types": "tsc",
 		"test": "xo && nyc ava && nyc report --reporter=text-lcov > coverage.lcov && codecov -t 54b3d620-a296-4d71-a717-c3e6e24ae9d9",
 		"prepare": "husky install && shx rm -rf .git/hooks && shx ln -s ../.husky .git/hooks"
 	},
+	"types": "types/index.d.ts",
 	"keywords": [
 		"ffprobe",
 		"binary"
@@ -18,7 +20,8 @@
 	"files": [
 		"index.js",
 		"lib",
-		"platform"
+		"platform",
+		"types"
 	],
 	"optionalDependencies": {
 		"@ffprobe-installer/darwin-arm64": "5.0.1",
@@ -38,7 +41,8 @@
 		"husky": "^8.0.3",
 		"nyc": "^15.1.0",
 		"shx": "^0.3.3",
-		"xo": "^0.53.1"
+		"xo": "^0.53.1",
+		"typescript": "^4.9.5"
 	},
 	"repository": {
 		"type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "include": [
+        "index.js",
+        "lib/**/*"
+    ],
+    "compilerOptions": {
+        "allowJs": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "skipLibCheck": true,
+        "outDir": "types/"
+    },
+}


### PR DESCRIPTION
The following changes mirror what is being done to generate types in [@ffmpeg-installer/ffmpeg](https://github.com/kribblo/node-ffmpeg-installer)

Utilizes `tsc` and JSdoc types to generate types. `npm run types` is added to the precommit hook and to package.json's `prepare` script.